### PR TITLE
Use official Strands agent runtime for local research runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+runs/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Automated Equity Research Copilot (Local Runner)
+
+This repository contains a local-first prototype of the Strands-powered equity research copilot. The `runner.py` entrypoint loads configuration from environment variables (or a `.env` file), instantiates the official `strands.Agent` runtime with custom research tools, and produces Markdown and JSON briefs for the requested tickers.
+
+## Getting Started
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python runner.py PLTR --focus "AI adoption in defense"
+```
+
+Outputs are saved to `runs/<timestamp>/brief.json` and `runs/<timestamp>/brief.md`.
+
+## Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `OPENAI_API_KEY` | Optional OpenAI API key for future extensions. |
+| `SEC_UA` | SEC EDGAR user agent string. Required for live filing retrieval. |
+| `NEWS_TOKEN` | NewsAPI token. Optional if using fixtures. |
+| `USE_FIXTURES` | When `true`, load canned data from `fixtures/` (default). |
+| `FIXTURES_PATH` | Override path to fixture directory. |
+| `RUNS_DIR` | Override output directory for generated briefs. |
+
+A sample `.env` file:
+
+```ini
+USE_FIXTURES=true
+SEC_UA="Example Contact (dev@example.com)"
+NEWS_TOKEN="newsapi-token"
+```
+
+## Testing
+
+Run the pytest suite to validate the offline fixture workflow:
+
+```bash
+pytest
+```

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,253 @@
+"""Research orchestration that runs on top of the Strands Agent runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import fmean
+from typing import Any, Dict, Iterable, List, Optional, cast
+
+from strands import Agent
+from strands.tools.decorator import DecoratedFunctionTool
+
+from tools import (
+    build_edgar_tool,
+    build_news_tool,
+    build_peers_tool,
+    build_prices_tool,
+    build_ratios_tool,
+    extract_json_content,
+)
+
+from settings import Settings
+
+
+@dataclass(slots=True)
+class RunArtifacts:
+    json_payload: Dict[str, Any]
+    markdown: str
+    output_dir: Path
+
+
+class ResearchAgent:
+    """Aggregate the individual tools to produce research artifacts."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+
+        self._tool_objects: Dict[str, DecoratedFunctionTool] = {
+            "prices": build_prices_tool(
+                use_fixtures=settings.use_fixtures,
+                fixtures_path=settings.fixtures_path,
+            ),
+            "news": build_news_tool(
+                use_fixtures=settings.use_fixtures,
+                fixtures_path=settings.fixtures_path,
+                news_token=settings.news_token,
+            ),
+            "edgar": build_edgar_tool(
+                use_fixtures=settings.use_fixtures,
+                fixtures_path=settings.fixtures_path,
+                sec_user_agent=settings.sec_user_agent,
+            ),
+            "ratios": build_ratios_tool(
+                use_fixtures=settings.use_fixtures,
+                fixtures_path=settings.fixtures_path,
+            ),
+            "peers": build_peers_tool(
+                use_fixtures=settings.use_fixtures,
+                fixtures_path=settings.fixtures_path,
+            ),
+        }
+
+        self.agent = Agent(
+            tools=list(self._tool_objects.values()),
+            system_prompt=(
+                "You are an equity research assistant that combines structured data sources "
+                "to produce concise, citation-backed insights."
+            ),
+        )
+
+    def run(self, tickers: Iterable[str], *, focus: Optional[str] = None) -> RunArtifacts:
+        tickers = [ticker.upper() for ticker in tickers]
+        generated_at = datetime.now(UTC)
+        run_id = generated_at.strftime("%Y%m%d_%H%M%S")
+        output_dir = self.settings.runs_dir / run_id
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        ticker_payloads: List[Dict[str, Any]] = []
+        markdown_sections: List[str] = ["# Research Brief"]
+        for ticker in tickers:
+            payload = self._gather_for_ticker(ticker)
+            payload["focus"] = focus
+            ticker_payloads.append(payload)
+            markdown_sections.append(self._format_markdown_for_ticker(payload))
+
+        json_payload = {
+            "run_id": run_id,
+            "generated_at": generated_at.isoformat() + "Z",
+            "tickers": ticker_payloads,
+        }
+        markdown = "\n\n".join(markdown_sections).strip() + "\n"
+        return RunArtifacts(json_payload=json_payload, markdown=markdown, output_dir=output_dir)
+
+    def _gather_for_ticker(self, ticker: str) -> Dict[str, Any]:
+        price_data = self._invoke_tool("prices", ticker=ticker)
+        ratio_data = self._invoke_tool("ratios", price_payload=price_data)
+        news_data = self._invoke_tool("news", ticker=ticker)
+        edgar_data = self._invoke_tool("edgar", ticker=ticker)
+        peers_data = self._invoke_tool("peers", ticker=ticker)
+
+        articles = news_data.get("articles", [])
+        avg_sentiment = fmean([article.get("sentiment", 0.0) for article in articles]) if articles else 0.0
+        positive_articles = [article for article in articles if article.get("sentiment", 0) >= 0]
+        negative_articles = [article for article in articles if article.get("sentiment", 0) < 0]
+
+        citations: List[Dict[str, str]] = []
+        for article in articles:
+            citations.append(
+                {
+                    "ticker": ticker,
+                    "title": article.get("title"),
+                    "url": article.get("url"),
+                    "source": article.get("source"),
+                    "published_at": article.get("published_at"),
+                }
+            )
+        citations.append(
+            {
+                "ticker": ticker,
+                "title": "Management discussion and analysis excerpt",
+                "url": str(self.settings.fixtures_path / f"filing_{ticker}_item7.html"),
+                "source": "SEC Filing Fixture" if self.settings.use_fixtures else "SEC EDGAR",
+                "published_at": "",
+            }
+        )
+
+        overview = self._build_overview(price_data, ratio_data, avg_sentiment)
+        moat = edgar_data.get("section", "Management commentary unavailable.")
+        performance = self._build_performance(ratio_data, price_data)
+        catalysts = self._summarise_articles(positive_articles)
+        risks = self._summarise_articles(negative_articles)
+        valuation = self._build_valuation(price_data)
+
+        return {
+            "ticker": ticker,
+            "prices": price_data,
+            "ratios": ratio_data,
+            "news": news_data,
+            "edgar": edgar_data,
+            "peers": peers_data,
+            "sentiment": {
+                "average": round(avg_sentiment, 2),
+                "article_count": len(articles),
+            },
+            "sections": {
+                "overview": overview,
+                "moat": moat,
+                "performance": performance,
+                "catalysts": catalysts,
+                "risks": risks,
+                "valuation": valuation,
+            },
+            "citations": citations,
+        }
+
+    def _format_markdown_for_ticker(self, payload: Dict[str, Any]) -> str:
+        ticker = payload["ticker"]
+        sections = payload["sections"]
+        peers = payload.get("peers", {}).get("peers", [])
+        citations = payload.get("citations", [])
+        focus = payload.get("focus")
+
+        lines = [f"## {ticker}"]
+        if focus:
+            lines.append(f"_Focus: {focus}_")
+        lines.extend(
+            [
+                "### Overview",
+                sections["overview"],
+                "### Moat",
+                sections["moat"],
+                "### Performance",
+                sections["performance"],
+                "### Catalysts",
+                sections["catalysts"],
+                "### Risks",
+                sections["risks"],
+                "### Valuation",
+                sections["valuation"],
+            ]
+        )
+        if peers:
+            lines.append("### Peers")
+            lines.append(", ".join(peers))
+
+        if citations:
+            lines.append("### Sources")
+            for idx, citation in enumerate(citations, start=1):
+                url = citation.get("url")
+                title = citation.get("title")
+                source = citation.get("source")
+                published = citation.get("published_at")
+                label = f"{title} — {source}"
+                if published:
+                    label += f" ({published})"
+                if url:
+                    lines.append(f"{idx}. [{label}]({url})")
+                else:
+                    lines.append(f"{idx}. {label}")
+        return "\n\n".join(lines)
+
+    def _invoke_tool(self, name: str, **kwargs: Any) -> Dict[str, Any]:
+        """Execute a Strands tool and extract its JSON payload."""
+
+        tool = self._tool_objects[name]
+        tool_caller = getattr(self.agent.tool, tool.tool_name)
+        result = tool_caller(**kwargs)
+        payload = extract_json_content(result)
+        return cast(Dict[str, Any], payload)
+
+    @staticmethod
+    def _build_overview(price_data: Dict[str, Any], ratio_data: Dict[str, float], sentiment: float) -> str:
+        latest_close = ratio_data.get("latest_close")
+        high = price_data.get("fifty_two_week_high")
+        low = price_data.get("fifty_two_week_low")
+        return (
+            f"Shares trade at ${latest_close:.2f} within a 52-week range of ${low:.2f}–${high:.2f}. "
+            f"Headline sentiment over the past week averages {sentiment:.2f}."
+        )
+
+    @staticmethod
+    def _build_performance(ratio_data: Dict[str, float], price_data: Dict[str, Any]) -> str:
+        sma20 = ratio_data.get("sma20")
+        sma50 = ratio_data.get("sma50")
+        rsi = ratio_data.get("rsi14")
+        latest = ratio_data.get("latest_close")
+        currency = price_data.get("currency", "USD")
+        return (
+            f"Latest close: {currency} {latest:.2f}. SMA20: {sma20:.2f}, SMA50: {sma50:.2f}, "
+            f"RSI14: {rsi:.2f}."
+        )
+
+    @staticmethod
+    def _summarise_articles(articles: List[Dict[str, Any]]) -> str:
+        if not articles:
+            return "No notable items in the latest coverage."
+        bullets = []
+        for article in articles[:3]:
+            summary = article.get("summary") or article.get("title")
+            source = article.get("source", "")
+            bullets.append(f"- {summary} ({source})")
+        return "\n".join(bullets)
+
+    @staticmethod
+    def _build_valuation(price_data: Dict[str, Any]) -> str:
+        high = price_data.get("fifty_two_week_high")
+        low = price_data.get("fifty_two_week_low")
+        latest = price_data.get("history", [])[-1]["close"] if price_data.get("history") else 0.0
+        distance_to_high = ((high - latest) / high * 100) if high else 0.0
+        return (
+            f"Trading {distance_to_high:.1f}% below the 52-week high of ${high:.2f}, "
+            f"with downside to the 52-week low at ${low:.2f}."
+        )

--- a/fixtures/filing_PLTR_item7.html
+++ b/fixtures/filing_PLTR_item7.html
@@ -1,0 +1,4 @@
+<h1>Management Discussion and Analysis</h1>
+<p>Palantir continued to scale its artificial intelligence platform across defense and commercial accounts during the fiscal period.</p>
+<p>Commercial revenue rose 32% year over year, driven by expanded deployments within healthcare and manufacturing clients.</p>
+<p>Management highlighted a growing pipeline of AI platform deals, while cautioning about lumpy government procurement cycles.</p>

--- a/fixtures/news_PLTR.json
+++ b/fixtures/news_PLTR.json
@@ -1,0 +1,29 @@
+{
+  "ticker": "PLTR",
+  "articles": [
+    {
+      "title": "Palantir expands AI platform with new government win",
+      "summary": "The company secured a multi-year defense analytics contract, highlighting momentum in classified AI deployments.",
+      "url": "https://news.example.com/palantir-defense-ai",
+      "published_at": "2024-04-04",
+      "sentiment": 0.4,
+      "source": "Example News"
+    },
+    {
+      "title": "Analysts debate sustainability of Palantir's valuation",
+      "summary": "Equity analysts caution that the stock already prices in aggressive growth assumptions, though backlog continues to build.",
+      "url": "https://news.example.com/palantir-valuation",
+      "published_at": "2024-04-03",
+      "sentiment": -0.1,
+      "source": "MarketWatch"
+    },
+    {
+      "title": "Commercial segment drives Palantir's latest quarterly beat",
+      "summary": "Commercial revenue grew 32% year over year as customers expand AI pilots to production workloads.",
+      "url": "https://news.example.com/palantir-commercial-growth",
+      "published_at": "2024-04-02",
+      "sentiment": 0.35,
+      "source": "Reuters"
+    }
+  ]
+}

--- a/fixtures/prices_PLTR.json
+++ b/fixtures/prices_PLTR.json
@@ -1,0 +1,18 @@
+{
+  "ticker": "PLTR",
+  "currency": "USD",
+  "history": [
+    {"date": "2024-03-25", "close": 23.15},
+    {"date": "2024-03-26", "close": 23.42},
+    {"date": "2024-03-27", "close": 23.05},
+    {"date": "2024-03-28", "close": 23.88},
+    {"date": "2024-03-29", "close": 24.12},
+    {"date": "2024-04-01", "close": 24.32},
+    {"date": "2024-04-02", "close": 24.08},
+    {"date": "2024-04-03", "close": 24.66},
+    {"date": "2024-04-04", "close": 24.91},
+    {"date": "2024-04-05", "close": 25.35}
+  ],
+  "fifty_two_week_high": 25.35,
+  "fifty_two_week_low": 9.55
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+python-dotenv>=1.0
+httpx>=0.27
+beautifulsoup4>=4.12
+yfinance>=0.2
+pandas>=2.2
+numpy>=1.26
+pytest>=8.0
+strands-agents>=1.9

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,46 @@
+"""Entry point for the automated equity research copilot."""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Iterable, Optional
+
+from agent import ResearchAgent, RunArtifacts
+from settings import Settings
+
+
+def run(tickers: Iterable[str], *, focus: Optional[str] = None) -> RunArtifacts:
+    """Run the research agent for the provided tickers and persist artifacts."""
+    settings = Settings.load()
+    settings.ensure_directories()
+    agent = ResearchAgent(settings)
+    artifacts = agent.run(tickers, focus=focus)
+
+    json_path = artifacts.output_dir / "brief.json"
+    md_path = artifacts.output_dir / "brief.md"
+
+    with json_path.open("w", encoding="utf-8") as handle:
+        json.dump(artifacts.json_payload, handle, indent=2)
+    md_path.write_text(artifacts.markdown, encoding="utf-8")
+
+    print(artifacts.markdown)
+    print(f"Saved outputs to {artifacts.output_dir}")
+    return artifacts
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate equity research briefs using the Strands runner.")
+    parser.add_argument("tickers", nargs="*", help="Ticker symbols to analyse", default=["PLTR"])
+    parser.add_argument("--focus", help="Optional focus prompt to steer the brief", default=None)
+    return parser
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    tickers = args.tickers or ["PLTR"]
+    run(tickers, focus=args.focus)
+
+
+if __name__ == "__main__":
+    main()

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,52 @@
+"""Settings loader for the Strands research runner."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency in offline mode
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - fallback when python-dotenv is absent
+    def load_dotenv(*args, **kwargs):
+        return False
+
+
+@dataclass(slots=True)
+class Settings:
+    """Configuration derived from environment variables or `.env`."""
+
+    openai_api_key: str | None
+    sec_user_agent: str | None
+    news_token: str | None
+    env: str
+    log_level: str
+    use_fixtures: bool
+    fixtures_path: Path
+    runs_dir: Path
+
+    @classmethod
+    def load(cls) -> "Settings":
+        load_dotenv()
+        def _get_bool(name: str, default: bool = False) -> bool:
+            value = os.getenv(name)
+            if value is None:
+                return default
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+
+        fixtures_path = Path(os.getenv("FIXTURES_PATH", "fixtures"))
+        runs_dir = Path(os.getenv("RUNS_DIR", "runs"))
+        return cls(
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            sec_user_agent=os.getenv("SEC_UA"),
+            news_token=os.getenv("NEWS_TOKEN"),
+            env=os.getenv("ENV", "dev"),
+            log_level=os.getenv("LOG_LEVEL", "INFO"),
+            use_fixtures=_get_bool("USE_FIXTURES", default=True),
+            fixtures_path=fixtures_path,
+            runs_dir=runs_dir,
+        )
+
+    def ensure_directories(self) -> None:
+        self.fixtures_path.mkdir(parents=True, exist_ok=True)
+        self.runs_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import runner
+
+
+def test_runner_generates_expected_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setenv("USE_FIXTURES", "1")
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    monkeypatch.setenv("FIXTURES_PATH", str(PROJECT_ROOT / "fixtures"))
+
+    artifacts = runner.run(["PLTR"], focus="AI adoption in defense")
+
+    json_path = artifacts.output_dir / "brief.json"
+    md_path = artifacts.output_dir / "brief.md"
+
+    assert json_path.exists()
+    assert md_path.exists()
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["tickers"][0]["ticker"] == "PLTR"
+    sections = payload["tickers"][0]["sections"]
+    for key in ["overview", "moat", "performance", "catalysts", "risks", "valuation"]:
+        assert key in sections
+        assert sections[key]
+
+    citations = payload["tickers"][0]["citations"]
+    assert len(citations) >= 3
+
+    markdown = md_path.read_text(encoding="utf-8")
+    for heading in ["### Overview", "### Moat", "### Performance", "### Catalysts", "### Risks", "### Valuation", "### Sources"]:
+        assert heading in markdown

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,23 @@
+"""Tool package exposing utility modules for the Strands research runner."""
+
+from .base import extract_json_content, json_tool_response
+from .edgar import EdgarTool, build_edgar_tool
+from .news import NewsTool, build_news_tool
+from .peers import PeersTool, build_peers_tool
+from .prices import PricesTool, build_prices_tool
+from .ratios import RatiosTool, build_ratios_tool
+
+__all__ = [
+    "PricesTool",
+    "NewsTool",
+    "EdgarTool",
+    "RatiosTool",
+    "PeersTool",
+    "build_prices_tool",
+    "build_news_tool",
+    "build_edgar_tool",
+    "build_ratios_tool",
+    "build_peers_tool",
+    "extract_json_content",
+    "json_tool_response",
+]

--- a/tools/base.py
+++ b/tools/base.py
@@ -1,0 +1,59 @@
+"""Base utilities shared by tool implementations."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+ToolResult = dict[str, Any]
+
+
+class BaseTool:
+    """Provide helpers for loading fixture payloads and resolving paths."""
+
+    def __init__(self, *, use_fixtures: bool, fixtures_path: Path) -> None:
+        self.use_fixtures = use_fixtures
+        self.fixtures_path = fixtures_path
+
+    def _fixture_path(self, name: str) -> Path:
+        path = self.fixtures_path / name
+        if not path.exists():
+            raise FileNotFoundError(f"Fixture '{name}' not found under {self.fixtures_path}.")
+        return path
+
+    def load_fixture_json(self, name: str) -> Any:
+        path = self._fixture_path(name)
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def load_fixture_text(self, name: str) -> str:
+        path = self._fixture_path(name)
+        return path.read_text(encoding="utf-8")
+
+
+def json_tool_response(payload: Any) -> ToolResult:
+    """Return a Strands tool response containing structured JSON content."""
+
+    return {
+        "status": "success",
+        "content": [{"json": payload}],
+    }
+
+
+def extract_json_content(tool_result: Mapping[str, Any], *, default: Any | None = None) -> Any:
+    """Extract the first JSON block from a Strands tool result."""
+
+    content: Iterable[Mapping[str, Any]] = tool_result.get("content", [])  # type: ignore[assignment]
+    for block in content:
+        if isinstance(block, Mapping) and "json" in block:
+            return block["json"]
+        if isinstance(block, Mapping) and "text" in block:
+            text = block["text"]
+            try:
+                return json.loads(text)
+            except (TypeError, ValueError):
+                return text
+    if default is not None:
+        return default
+    raise ValueError("Tool result did not include JSON or text content.")

--- a/tools/edgar.py
+++ b/tools/edgar.py
@@ -1,0 +1,85 @@
+"""SEC EDGAR helper to retrieve filing excerpts."""
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Dict
+
+try:  # pragma: no cover - optional dependency for live mode
+    import httpx
+except Exception:  # pragma: no cover - offline fallback
+    httpx = None
+
+from strands.tools import tool
+from strands.tools.decorator import DecoratedFunctionTool
+
+from .base import BaseTool, json_tool_response
+
+
+class EdgarTool(BaseTool):
+    """Fetch Item 7 style MD&A snippets for a ticker."""
+
+    def __init__(self, *, use_fixtures: bool, fixtures_path: Path, sec_user_agent: str | None) -> None:
+        super().__init__(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+        self.sec_user_agent = sec_user_agent
+
+    def fetch(self, ticker: str) -> Dict[str, str]:
+        ticker = ticker.upper()
+        if self.use_fixtures or not self.sec_user_agent:
+            html = self.load_fixture_text(f"filing_{ticker}_item7.html")
+            return {"ticker": ticker, "section": self._extract_text(html)}
+        return self._fetch_live_html(ticker)
+
+    def _fetch_live_html(self, ticker: str) -> Dict[str, str]:
+        if not self.sec_user_agent:
+            raise RuntimeError("SEC user agent is required for live EDGAR calls.")
+        if httpx is None:
+            raise RuntimeError("httpx is required for live EDGAR calls but is not installed.")
+        headers = {"User-Agent": self.sec_user_agent}
+        params = {"ticker": ticker, "type": "10-K", "count": 1}
+        with httpx.Client(timeout=10, headers=headers) as client:
+            response = client.get("https://data.sec.gov/submissions/CIK0001321655.json", params=params)
+            response.raise_for_status()
+        # Placeholder: in real implementation parse JSON to locate filing URL.
+        return {"ticker": ticker, "section": "Live EDGAR fetching not implemented in this offline build."}
+
+    @staticmethod
+    def _extract_text(html: str) -> str:
+        class ParagraphCollector(HTMLParser):
+            def __init__(self) -> None:
+                super().__init__()
+                self.in_paragraph = False
+                self.chunks: list[str] = []
+
+            def handle_starttag(self, tag, attrs):  # type: ignore[override]
+                if tag.lower() == "p":
+                    self.in_paragraph = True
+
+            def handle_endtag(self, tag):  # type: ignore[override]
+                if tag.lower() == "p":
+                    self.in_paragraph = False
+
+            def handle_data(self, data):  # type: ignore[override]
+                if self.in_paragraph:
+                    text = data.strip()
+                    if text:
+                        self.chunks.append(text)
+
+        parser = ParagraphCollector()
+        parser.feed(html)
+        return " ".join(parser.chunks)
+
+
+def build_edgar_tool(
+    *, use_fixtures: bool, fixtures_path: Path, sec_user_agent: str | None
+) -> DecoratedFunctionTool:
+    """Create a Strands tool for fetching SEC MD&A excerpts."""
+
+    backend = EdgarTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path, sec_user_agent=sec_user_agent)
+
+    @tool(name="edgar", description="Fetch Item 7 management commentary for a ticker.")
+    def edgar_tool(ticker: str) -> Dict[str, str]:
+        payload = backend.fetch(ticker)
+        return json_tool_response(payload)
+
+    return edgar_tool

--- a/tools/news.py
+++ b/tools/news.py
@@ -1,0 +1,89 @@
+"""News headlines and naive sentiment scoring."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:  # pragma: no cover - optional dependency for live mode
+    import httpx
+except Exception:  # pragma: no cover - offline fallback
+    httpx = None
+
+from strands.tools import tool
+from strands.tools.decorator import DecoratedFunctionTool
+
+from .base import BaseTool, json_tool_response
+
+
+class NewsTool(BaseTool):
+    """Fetch recent headlines for a ticker using NewsAPI or fixtures."""
+
+    def __init__(self, *, use_fixtures: bool, fixtures_path: Path, news_token: str | None) -> None:
+        super().__init__(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+        self.news_token = news_token
+
+    def fetch(self, ticker: str) -> Dict[str, Any]:
+        ticker = ticker.upper()
+        if self.use_fixtures or not self.news_token:
+            return self.load_fixture_json(f"news_{ticker}.json")
+        return self._fetch_live_news(ticker)
+
+    def _fetch_live_news(self, ticker: str) -> Dict[str, Any]:
+        if httpx is None:
+            raise RuntimeError("httpx is required for live news fetching but is not installed.")
+        end = datetime.utcnow()
+        start = end - timedelta(days=7)
+        params = {
+            "q": ticker,
+            "language": "en",
+            "sortBy": "publishedAt",
+            "pageSize": 10,
+            "from": start.strftime("%Y-%m-%d"),
+            "to": end.strftime("%Y-%m-%d"),
+            "apiKey": self.news_token,
+        }
+        with httpx.Client(timeout=10) as client:
+            response = client.get("https://newsapi.org/v2/everything", params=params)
+            response.raise_for_status()
+        payload = response.json()
+        articles = []
+        for article in payload.get("articles", []):
+            articles.append(
+                {
+                    "title": article.get("title"),
+                    "summary": article.get("description"),
+                    "url": article.get("url"),
+                    "published_at": article.get("publishedAt", "")[:10],
+                    "sentiment": self._naive_sentiment(article.get("description", "")),
+                    "source": article.get("source", {}).get("name"),
+                }
+            )
+        return {"ticker": ticker, "articles": articles}
+
+    @staticmethod
+    def _naive_sentiment(text: str) -> float:
+        text = text.lower()
+        positive = sum(text.count(word) for word in ("growth", "beat", "win", "strong"))
+        negative = sum(text.count(word) for word in ("risk", "concern", "loss", "slow"))
+        if positive == negative:
+            return 0.0
+        total = positive + negative
+        if total == 0:
+            return 0.0
+        return round((positive - negative) / total, 2)
+
+
+def build_news_tool(
+    *, use_fixtures: bool, fixtures_path: Path, news_token: str | None
+) -> DecoratedFunctionTool:
+    """Create a Strands tool that fetches recent news articles."""
+
+    backend = NewsTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path, news_token=news_token)
+
+    @tool(name="news", description="Fetch NewsAPI headlines and naive sentiment for a ticker symbol.")
+    def news_tool(ticker: str) -> Dict[str, Any]:
+        payload = backend.fetch(ticker)
+        return json_tool_response(payload)
+
+    return news_tool

--- a/tools/peers.py
+++ b/tools/peers.py
@@ -1,0 +1,42 @@
+"""Hard-coded peer groups for key tickers."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from strands.tools import tool
+from strands.tools.decorator import DecoratedFunctionTool
+
+from .base import BaseTool, json_tool_response
+
+
+_PEER_MAP: Dict[str, List[str]] = {
+    "PLTR": ["SNOW", "DDOG", "MSFT"],
+    "MSFT": ["GOOGL", "AMZN", "AAPL"],
+    "SNOW": ["PLTR", "DDOG", "MDB"],
+}
+
+
+class PeersTool(BaseTool):
+    """Return a static peer group for a ticker."""
+
+    def __init__(self, *, use_fixtures: bool, fixtures_path: Path) -> None:
+        super().__init__(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+
+    def fetch(self, ticker: str) -> Dict[str, List[str]]:
+        ticker = ticker.upper()
+        peers = _PEER_MAP.get(ticker, [])
+        return {"ticker": ticker, "peers": peers}
+
+
+def build_peers_tool(*, use_fixtures: bool, fixtures_path: Path) -> DecoratedFunctionTool:
+    """Create a Strands tool that returns static peer groups."""
+
+    backend = PeersTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+
+    @tool(name="peers", description="Return a static list of comparable tickers for the target company.")
+    def peers_tool(ticker: str) -> Dict[str, List[str]]:
+        payload = backend.fetch(ticker)
+        return json_tool_response(payload)
+
+    return peers_tool

--- a/tools/prices.py
+++ b/tools/prices.py
@@ -1,0 +1,69 @@
+"""Price history and snapshot metrics sourced from Yahoo Finance."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+import statistics
+
+try:
+    import yfinance as yf
+except Exception:  # pragma: no cover - optional dependency for offline mode
+    yf = None
+
+from strands.tools import tool
+from strands.tools.decorator import DecoratedFunctionTool
+
+from .base import BaseTool, json_tool_response
+
+
+class PricesTool(BaseTool):
+    """Fetch price history and derived metrics for a ticker."""
+
+    def fetch(self, ticker: str) -> Dict[str, Any]:
+        ticker = ticker.upper()
+        if self.use_fixtures:
+            return self.load_fixture_json(f"prices_{ticker}.json")
+        if yf is None:
+            raise RuntimeError("yfinance is required for live price fetching but is not installed.")
+
+        history = self._download_history(ticker)
+        closes = [item["close"] for item in history]
+        latest_close = closes[-1]
+        return {
+            "ticker": ticker,
+            "currency": "USD",
+            "history": history,
+            "fifty_two_week_high": max(closes),
+            "fifty_two_week_low": min(closes),
+            "latest_close": latest_close,
+            "avg_close_30d": round(statistics.fmean(closes[-30:]), 2) if len(closes) >= 30 else latest_close,
+        }
+
+    def _download_history(self, ticker: str) -> List[Dict[str, Any]]:
+        end = datetime.utcnow()
+        start = end - timedelta(days=120)
+        data = yf.download(ticker, start=start, end=end, progress=False, auto_adjust=True)
+        if data.empty:
+            raise ValueError(f"No price data returned for {ticker}.")
+        history: List[Dict[str, Any]] = []
+        for index, row in data.tail(90).iterrows():
+            history.append({
+                "date": index.strftime("%Y-%m-%d"),
+                "close": round(float(row["Close"]), 2),
+            })
+        return history
+
+
+def build_prices_tool(*, use_fixtures: bool, fixtures_path: Path) -> DecoratedFunctionTool:
+    """Create a Strands tool for fetching price payloads."""
+
+    backend = PricesTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+
+    @tool(name="prices", description="Fetch price history and summary statistics for an equity ticker.")
+    def prices_tool(ticker: str) -> Dict[str, Any]:
+        payload = backend.fetch(ticker)
+        return json_tool_response(payload)
+
+    return prices_tool

--- a/tools/ratios.py
+++ b/tools/ratios.py
@@ -1,0 +1,66 @@
+"""Technical ratio helpers derived from price history."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from strands.tools import tool
+from strands.tools.decorator import DecoratedFunctionTool
+
+from .base import BaseTool, json_tool_response
+
+
+def _sma(values: Iterable[float]) -> float:
+    values = list(values)
+    if not values:
+        return 0.0
+    return round(sum(values) / len(values), 2)
+
+
+def _rsi(prices: List[float], period: int = 14) -> float:
+    if len(prices) < period + 1:
+        return 50.0
+    gains = []
+    losses = []
+    for i in range(1, period + 1):
+        change = prices[-i] - prices[-i - 1]
+        if change >= 0:
+            gains.append(change)
+        else:
+            losses.append(abs(change))
+    avg_gain = sum(gains) / period if gains else 0.0
+    avg_loss = sum(losses) / period if losses else 0.0
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return round(100 - (100 / (1 + rs)), 2)
+
+
+class RatiosTool(BaseTool):
+    """Compute SMA20, SMA50, and RSI14 from price history."""
+
+    def __init__(self, *, use_fixtures: bool, fixtures_path: Path) -> None:
+        super().__init__(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+
+    def compute(self, price_payload: Dict[str, Any]) -> Dict[str, float]:
+        history = price_payload.get("history", [])
+        closes = [float(row["close"]) for row in history]
+        return {
+            "sma20": _sma(closes[-20:]),
+            "sma50": _sma(closes[-50:]),
+            "rsi14": _rsi(closes, period=14),
+            "latest_close": closes[-1] if closes else 0.0,
+        }
+
+
+def build_ratios_tool(*, use_fixtures: bool, fixtures_path: Path) -> DecoratedFunctionTool:
+    """Create a Strands tool to compute technical ratios from price payloads."""
+
+    backend = RatiosTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+
+    @tool(name="ratios", description="Compute SMA and RSI metrics from price history data.")
+    def ratios_tool(price_payload: Dict[str, Any]) -> Dict[str, float]:
+        payload = backend.compute(price_payload)
+        return json_tool_response(payload)
+
+    return ratios_tool


### PR DESCRIPTION
## Summary
- instantiate the official `strands.Agent` runtime with configured research tools inside the local runner
- wrap price, news, edgar, ratios, and peers helpers in Strands tool decorators and add JSON parsing utilities
- document the Strands dependency and include the SDK in the project requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08a598c0c8327ac446bd2153f21a7