### PR TITLE
Wire Strands to OpenAI & Bedrock; enable live calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 runs/
 .env
+.sec_cache/

--- a/README.md
+++ b/README.md
@@ -8,33 +8,36 @@ This repository contains a local-first prototype of the Strands-powered equity r
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-python runner.py AMZN --focus "Logistics automation and Prime retention"
+python runner.py AMZN --focus "AWS's power to keep on bringing strong revenue gains"
 ```
 
 Outputs are saved to `runs/<timestamp>/brief.json` and `runs/<timestamp>/brief.md`.
 
 ## Environment Variables
 
-| Variable | Description |
-| --- | --- |
-| `OPENAI_API_KEY` | Optional OpenAI API key for future extensions. |
-| `SEC_UA` | SEC EDGAR user agent string. Required for live filing retrieval. |
-| `NEWS_TOKEN` | NewsAPI token. Optional if using fixtures. |
-| `USE_FIXTURES` | When `true`, load canned data from `fixtures/` (default). |
-| `FIXTURES_PATH` | Override path to fixture directory. |
-| `RUNS_DIR` | Override output directory for generated briefs. |
+| Variable         | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| `OPENAI_API_KEY` | OpenAI API key for model inference. Optional when using Bedrock. |
+| `OPENAI_MODEL_ID`| Override the default OpenAI model (`gpt-4o-mini`).               |
+| `SEC_UA`         | SEC EDGAR user agent string. Required for live filing retrieval. |
+| `NEWS_TOKEN`     | NewsAPI token. Optional when falling back to GDELT headlines.    |
+| `BEDROCK_MODEL_ID` | Optional Bedrock model id (default `anthropic.claude-3-haiku-20240307-v1:0`). |
+| `AWS_REGION`     | AWS region for Bedrock when using AWS credentials.               |
+| `RUNS_DIR`       | Override output directory for generated briefs.                  |
 
 A sample `.env` file:
 
 ```ini
-USE_FIXTURES=true
+OPENAI_API_KEY="sk-..."  # or omit when using AWS Bedrock
 SEC_UA="Example Contact (dev@example.com)"
-NEWS_TOKEN="newsapi-token"
+NEWS_TOKEN="newsapi-token"  # optional, falls back to GDELT when absent
+BEDROCK_MODEL_ID="anthropic.claude-3-haiku-20240307-v1:0"  # optional
+AWS_REGION="us-east-1"  # required when using Bedrock
 ```
 
 ## Testing
 
-Run the pytest suite to validate the offline fixture workflow:
+Run the pytest suite to verify configuration guards:
 
 ```bash
 pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automated Equity Research Copilot (Local Runner)
 
-This repository contains a local-first prototype of the Strands-powered equity research copilot. The `runner.py` entrypoint loads configuration from environment variables (or a `.env` file), instantiates the official `strands.Agent` runtime with custom research tools, and produces Markdown and JSON briefs for the requested tickers.
+This repository contains a live-data Strands-powered equity research copilot. The `runner.py` entrypoint loads configuration from environment variables (or a `.env` file), instantiates the official `strands.Agent` runtime with custom research tools that call OpenAI (or AWS Bedrock), Yahoo Finance, NewsAPI/GDELT, and the SEC submissions API, then produces Markdown and JSON briefs for the requested tickers.
 
 ## Getting Started
 
@@ -9,6 +9,8 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 python runner.py AMZN --focus "AWS's power to keep on bringing strong revenue gains"
+# smoke-test live tooling without writing outputs
+python runner.py NXE --test
 ```
 
 Outputs are saved to `runs/<timestamp>/brief.json` and `runs/<timestamp>/brief.md`.
@@ -17,27 +19,87 @@ Outputs are saved to `runs/<timestamp>/brief.json` and `runs/<timestamp>/brief.m
 
 | Variable         | Description                                                      |
 | ---------------- | ---------------------------------------------------------------- |
-| `OPENAI_API_KEY` | OpenAI API key for model inference. Optional when using Bedrock. |
+| `OPENAI_API_KEY` | OpenAI API key for the analysis model. Required unless Bedrock is used. |
 | `OPENAI_MODEL_ID`| Override the default OpenAI model (`gpt-4o-mini`).               |
 | `SEC_UA`         | SEC EDGAR user agent string. Required for live filing retrieval. |
 | `NEWS_TOKEN`     | NewsAPI token. Optional when falling back to GDELT headlines.    |
 | `BEDROCK_MODEL_ID` | Optional Bedrock model id (default `anthropic.claude-3-haiku-20240307-v1:0`). |
-| `AWS_REGION`     | AWS region for Bedrock when using AWS credentials.               |
+| `AWS_REGION`     | AWS region for Bedrock (use with AWS credentials).               |
+| `AWS_ACCESS_KEY_ID` / `AWS_PROFILE` / etc. | Provide one of the standard AWS credential mechanisms if you want Bedrock instead of OpenAI. |
 | `RUNS_DIR`       | Override output directory for generated briefs.                  |
 
 A sample `.env` file:
 
 ```ini
-OPENAI_API_KEY="sk-..."  # or omit when using AWS Bedrock
+OPENAI_API_KEY="sk-..."  # omit when using AWS Bedrock auth
 SEC_UA="Example Contact (dev@example.com)"
-NEWS_TOKEN="newsapi-token"  # optional, falls back to GDELT when absent
-BEDROCK_MODEL_ID="anthropic.claude-3-haiku-20240307-v1:0"  # optional
+NEWS_TOKEN="newsapi-token"  # optional; falls back to GDELT when absent
+BEDROCK_MODEL_ID="anthropic.claude-3-haiku-20240307-v1:0"  # optional override
 AWS_REGION="us-east-1"  # required when using Bedrock
+AWS_PROFILE="bedrock-programmatic"  # or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
+```
+
+> **Note:** The runner operates in live mode only. If model credentials, the SEC user agent, or external data sources are unavailable, execution aborts instead of falling back to cached data; use `--test` to surface a summary of any failing tools without writing artifacts.
+
+## Example Output
+
+```bash
+python3 runner.py AMZN --focus "AWS's revenue growth"
+```
+
+```
+# Research Brief
+
+## AMZN
+
+_Focus: AWS's revenue growth_
+
+### Overview
+
+Amazon.com, Inc. (AMZN) continues to demonstrate resilience in its performance with a current share price of $231.48, reflecting a substantial recovery from its year-to-date low of $204.72. The stock has achieved a 52-week high of $238.24, bolstered by strong earnings growth, which includes a dramatic increase in net income from $13.49 billion in Q2 2024 to $18.16 billion in Q2 2025. The company has effectively leveraged its massive customer base and technological infrastructure to sustain competitive advantages in eCommerce and cloud services, positioning itself favorably for future growth in diversified sectors like artificial intelligence and entertainment.
+
+### Moat
+
+Amazon's competitive moat is characterized by its broad range of services, customer-centric approach, and infrastructural prowess, particularly within its Amazon Web Services (AWS) segment. The latest financial results indicate a significant expansion of operating income, marking a 30% increase year-over-year, which underlines the company’s ability to maintain pricing power without sacrificing profitability. Additionally, the intricacies of the AWS ecosystem, supported by the company's commitment to innovation and continuous investment in advanced technologies, fortify its market presence against emerging competitors like Microsoft (MSFT) and Google (GOOGL).
+
+### Performance
+
+Analyzing recent performance metrics, AMZN has exhibited a stable recovery pattern with an average closing price of $229.14 over the last month, peaking at $238.24. The 14-day Relative Strength Index (RSI) stands at 52.93, indicating a balanced distribution of buy and sell signals, a positive hint for potential upward momentum. Furthermore, with a simple moving average (SMA) of 20-days at $230.84, AMZN remains above both its short-term indicators and well-positioned against broader market performance, suggesting investor confidence despite external market pressures.
+
+### Catalysts
+
+Several catalysts could drive Amazon's growth trajectory, including increased adoption of artificial intelligence and enhancements to its logistics network. Recent commentary from market analysts, including insights from Jim Cramer, suggests optimism regarding AMZN's strategic investment in AI and expansion into new digital services, which are expected to enhance customer engagement and operational efficiency. As the company ramps up efforts in original content production and streaming services, strengthened revenue from these sectors may yield robust earnings growth, compounding shareholder value. Additionally, the ongoing efforts in the AWS segment to offer innovative solutions could further invigorate revenue streams.
+
+### Risks
+
+While AMZN presents numerous growth opportunities, inherent risks persist, primarily stemming from regulatory scrutiny, increased competition, and potential supply chain disruptions. The recent filings noted a significant reliance on international markets, which could expose the company to foreign exchange fluctuations and geopolitical uncertainties. Future operating results could be affected negatively if Amazon fails to manage rising operational costs or if the adoption rates of new technologies do not meet stakeholder expectations, potentially undermining its robust market position.
+
+### Valuation
+
+Amazon's valuation reflects confidence in its long-term growth potential, with a current trading price that suggests steady investor optimism. By comparing valuation metrics, AMZN's price-to-earnings (P/E) ratio situates favorably against peers like Microsoft (MSFT) and Walmart (WMT) as it encapsulates a broader view of market expectations, affirming AMZN's status as a frontrunner in eCommerce and technology services. The company's forward-looking investments, while initially impacting short-term margins, are anticipated to yield favorable long-term returns, thereby enhancing its market valuation.
+
+### Peers
+
+MSFT, GOOGL, WMT
+
+### Sources
+
+1. [Aces High 1976 1008p AMZN WEB-DL H264-GPRS — Rlsbb.to (2025-09-20)](https://post.rlsbb.to/aces-high-1976-1008p-amzn-web-dl-h264-gprs-2/)
+2. [Shadows in the Sun 2005 1080p AMZN WEB-DL H264-GPRS — Rlsbb.to (2025-09-20)](https://post.rlsbb.to/shadows-in-the-sun-2005-1080p-amzn-web-dl-h264-gprs/)
+3. [TD Cowen Sees Upside in Alphabet (GOOGL) With Rising GenAI Adoption — Yahoo Entertainment (2025-09-20)](https://finance.yahoo.com/news/td-cowen-sees-upside-alphabet-211302489.html)
+4. [Aces High 1976 1008p AMZN WEB-DL H264-GPRS — Rlsbb.to (2025-09-20)](https://post.rlsbb.to/aces-high-1976-1008p-amzn-web-dl-h264-gprs/)
+5. [Glassland 2014 1080p AMZN WEB-DL H264-GPRS — Rlsbb.to (2025-09-20)](https://post.rlsbb.to/glassland-2014-1080p-amzn-web-dl-h264-gprs/)
+6. [“We Were So Worried About” Amazon.com, Inc. (AMZN), Says Jim Cramer — Biztoc.com (2025-09-20)](https://biztoc.com/x/43cbbd936147aeac)
+7. [Monsters And Men 2018 1080p AMZN WEB-DL H264-GPRS — Rlsbb.to (2025-09-20)](https://post.rlsbb.to/monsters-and-men-2018-1080p-amzn-web-dl-h264-gprs/)
+8. [The Perfect Weapon 2016 1080p AMZN WEB-DL H264-GPRS — Rlsbb.to (2025-09-20)](https://post.rlsbb.to/the-perfect-weapon-2016-1080p-amzn-web-dl-h264-gprs/)
+9. [Into The Deep 2022 1080p AMZN WEB-DL H264-GPRS — Rlsbb.to (2025-09-20)](https://post.rlsbb.to/into-the-deep-2022-1080p-amzn-web-dl-h264-gprs/)
+10. [“We Were So Worried About” Amazon.com, Inc. (AMZN), Says Jim Cramer — Yahoo Entertainment (2025-09-20)](https://finance.yahoo.com/news/were-worried-amazon-com-inc-190530622.html)
+11. [Management discussion and analysis excerpt — SEC EDGAR (2025-08-01)](https://www.sec.gov/Archives/edgar/data/1018724/000101872425000086/amzn-20250630.htm)
 ```
 
 ## Testing
 
-Run the pytest suite to verify configuration guards:
+Run the pytest suite to verify the live-only configuration wiring:
 
 ```bash
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dotenv>=1.0
-httpx>=0.27
+httpx>=0.27,<0.28
 beautifulsoup4>=4.12
 yfinance>=0.2
 pandas>=2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ yfinance>=0.2
 pandas>=2.2
 numpy>=1.26
 pytest>=8.0
-strands-agents>=1.9
+strands-agents==1.9.1
+openai==1.40.0
 pydantic>=2.0

--- a/runner.py
+++ b/runner.py
@@ -3,17 +3,65 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from typing import Iterable, Optional
+
+from dotenv import load_dotenv
+from strands.models.bedrock import BedrockModel
+from strands.models.openai import OpenAIModel
 
 from agent import ResearchAgent, RunArtifacts
 from settings import Settings
+
+
+load_dotenv()
+
+
+def _create_model(settings: Settings) -> object:
+    """Initialise a Strands model using OpenAI or Bedrock credentials."""
+
+    api_key = settings.openai_api_key or os.getenv("OPENAI_API_KEY")
+    if api_key:
+        model_id = os.getenv("OPENAI_MODEL_ID", "gpt-4o-mini")
+        return OpenAIModel(
+            client_args={"api_key": api_key},
+            model_id=model_id,
+            params={"max_tokens": 2000, "temperature": 0.2},
+        )
+
+    bedrock_model_id = os.getenv("BEDROCK_MODEL_ID", "anthropic.claude-3-haiku-20240307-v1:0")
+    region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+    has_aws_credentials = any(
+        os.getenv(name)
+        for name in (
+            "AWS_PROFILE",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_ROLE_ARN",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+        )
+    )
+    if not has_aws_credentials:
+        raise RuntimeError("Provide either OPENAI_API_KEY or AWS credentials to run the research agent.")
+
+    model_args: dict[str, object] = {
+        "model_id": bedrock_model_id,
+        "max_tokens": 2000,
+        "temperature": 0.2,
+    }
+    if region:
+        model_args["region_name"] = region
+
+    return BedrockModel(**model_args)
 
 
 def run(tickers: Iterable[str], *, focus: Optional[str] = None) -> RunArtifacts:
     """Run the research agent for the provided tickers and persist artifacts."""
     settings = Settings.load()
     settings.ensure_directories()
-    agent = ResearchAgent(settings)
+
+    model = _create_model(settings)
+
+    agent = ResearchAgent(settings, model=model)
     artifacts = agent.run(tickers, focus=focus)
 
     json_path = artifacts.output_dir / "brief.json"

--- a/settings.py
+++ b/settings.py
@@ -21,24 +21,12 @@ class Settings:
     news_token: str | None
     env: str
     log_level: str
-    use_fixtures: bool
-    fixtures_path: Path
     runs_dir: Path
 
     @classmethod
     def load(cls) -> "Settings":
         load_dotenv()
-        def _get_bool(name: str, default: bool = False) -> bool:
-            value = os.getenv(name)
-            if value is None:
-                return default
-            return value.strip().lower() in {"1", "true", "yes", "on"}
-
-        fixtures_path = Path(os.getenv("FIXTURES_PATH", "fixtures"))
         runs_dir = Path(os.getenv("RUNS_DIR", "runs"))
-
-        if _get_bool("USE_FIXTURES", default=False):
-            raise ValueError("Offline fixture mode is disabled. Remove USE_FIXTURES from the environment.")
 
         return cls(
             openai_api_key=os.getenv("OPENAI_API_KEY"),
@@ -46,11 +34,8 @@ class Settings:
             news_token=os.getenv("NEWS_TOKEN"),
             env=os.getenv("ENV", "dev"),
             log_level=os.getenv("LOG_LEVEL", "INFO"),
-            use_fixtures=False,
-            fixtures_path=fixtures_path,
             runs_dir=runs_dir,
         )
 
     def ensure_directories(self) -> None:
-        self.fixtures_path.mkdir(parents=True, exist_ok=True)
         self.runs_dir.mkdir(parents=True, exist_ok=True)

--- a/settings.py
+++ b/settings.py
@@ -36,13 +36,17 @@ class Settings:
 
         fixtures_path = Path(os.getenv("FIXTURES_PATH", "fixtures"))
         runs_dir = Path(os.getenv("RUNS_DIR", "runs"))
+
+        if _get_bool("USE_FIXTURES", default=False):
+            raise ValueError("Offline fixture mode is disabled. Remove USE_FIXTURES from the environment.")
+
         return cls(
             openai_api_key=os.getenv("OPENAI_API_KEY"),
             sec_user_agent=os.getenv("SEC_UA"),
             news_token=os.getenv("NEWS_TOKEN"),
             env=os.getenv("ENV", "dev"),
             log_level=os.getenv("LOG_LEVEL", "INFO"),
-            use_fixtures=_get_bool("USE_FIXTURES", default=True),
+            use_fixtures=False,
             fixtures_path=fixtures_path,
             runs_dir=runs_dir,
         )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -12,7 +10,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from settings import Settings
 
 
-def test_fixture_mode_is_disabled(monkeypatch):
+def test_settings_is_online_only(monkeypatch):
     monkeypatch.setenv("USE_FIXTURES", "1")
-    with pytest.raises(ValueError, match="Offline fixture mode is disabled"):
-        Settings.load()
+    settings = Settings.load()
+    assert not hasattr(settings, "use_fixtures")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,46 +1,18 @@
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
-import re
 
+import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-import runner
+from settings import Settings
 
 
-def test_runner_generates_expected_artifacts(tmp_path, monkeypatch):
+def test_fixture_mode_is_disabled(monkeypatch):
     monkeypatch.setenv("USE_FIXTURES", "1")
-    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
-    monkeypatch.setenv("FIXTURES_PATH", str(PROJECT_ROOT / "fixtures"))
-
-    artifacts = runner.run(["AMZN"], focus="Logistics automation and Prime retention")
-
-    json_path = artifacts.output_dir / "brief.json"
-    md_path = artifacts.output_dir / "brief.md"
-
-    assert json_path.exists()
-    assert md_path.exists()
-
-    payload = json.loads(json_path.read_text(encoding="utf-8"))
-    assert payload["tickers"][0]["ticker"] == "AMZN"
-    sections = payload["tickers"][0]["sections"]
-    for key in ["overview", "moat", "performance", "catalysts", "risks", "valuation"]:
-        assert key in sections
-        assert sections[key]
-        sentences = re.findall(r"[^.!?]+[.!?]", sections[key])
-        has_paragraph_break = "\n\n" in sections[key]
-        assert len(sentences) >= 2 or has_paragraph_break, (
-            f"Section '{key}' should contain multi-sentence or multi-paragraph analysis."
-        )
-
-    citations = payload["tickers"][0]["citations"]
-    assert len(citations) >= 3
-
-    markdown = md_path.read_text(encoding="utf-8")
-    for heading in ["### Overview", "### Moat", "### Performance", "### Catalysts", "### Risks", "### Valuation", "### Sources"]:
-        assert heading in markdown
+    with pytest.raises(ValueError, match="Offline fixture mode is disabled"):
+        Settings.load()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,18 +1,13 @@
-"""Tool package exposing utility modules for the Strands research runner."""
+"""Tool package exposing live-data helpers for the Strands research runner."""
 
 from .base import extract_json_content, json_tool_response
-from .edgar import EdgarTool, build_edgar_tool
-from .news import NewsTool, build_news_tool
-from .peers import PeersTool, build_peers_tool
-from .prices import PricesTool, build_prices_tool
-from .ratios import RatiosTool, build_ratios_tool
+from .edgar import build_edgar_tool
+from .news import build_news_tool
+from .peers import build_peers_tool
+from .prices import build_prices_tool
+from .ratios import build_ratios_tool
 
 __all__ = [
-    "PricesTool",
-    "NewsTool",
-    "EdgarTool",
-    "RatiosTool",
-    "PeersTool",
     "build_prices_tool",
     "build_news_tool",
     "build_edgar_tool",

--- a/tools/base.py
+++ b/tools/base.py
@@ -1,35 +1,11 @@
-"""Base utilities shared by tool implementations."""
+"""Shared helpers for Strands tool implementations."""
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 
 ToolResult = dict[str, Any]
-
-
-class BaseTool:
-    """Provide helpers for loading fixture payloads and resolving paths."""
-
-    def __init__(self, *, use_fixtures: bool, fixtures_path: Path) -> None:
-        self.use_fixtures = use_fixtures
-        self.fixtures_path = fixtures_path
-
-    def _fixture_path(self, name: str) -> Path:
-        path = self.fixtures_path / name
-        if not path.exists():
-            raise FileNotFoundError(f"Fixture '{name}' not found under {self.fixtures_path}.")
-        return path
-
-    def load_fixture_json(self, name: str) -> Any:
-        path = self._fixture_path(name)
-        with path.open("r", encoding="utf-8") as handle:
-            return json.load(handle)
-
-    def load_fixture_text(self, name: str) -> str:
-        path = self._fixture_path(name)
-        return path.read_text(encoding="utf-8")
 
 
 def json_tool_response(payload: Any) -> ToolResult:

--- a/tools/edgar.py
+++ b/tools/edgar.py
@@ -1,15 +1,19 @@
 """SEC EDGAR helper to retrieve filing excerpts."""
 from __future__ import annotations
 
-from html.parser import HTMLParser
+import re
+from datetime import datetime
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
+from urllib.parse import urljoin
+from xml.etree import ElementTree
 
 try:  # pragma: no cover - optional dependency for live mode
     import httpx
 except Exception:  # pragma: no cover - offline fallback
     httpx = None
 
+from bs4 import BeautifulSoup, NavigableString
 from strands.tools import tool
 from strands.tools.decorator import DecoratedFunctionTool
 
@@ -25,9 +29,10 @@ class EdgarTool(BaseTool):
 
     def fetch(self, ticker: str) -> Dict[str, str]:
         ticker = ticker.upper()
-        if self.use_fixtures or not self.sec_user_agent:
-            html = self.load_fixture_text(f"filing_{ticker}_item7.html")
-            return {"ticker": ticker, "section": self._extract_text(html)}
+        if self.use_fixtures:
+            raise RuntimeError("Fixture mode is disabled; live SEC data is required.")
+        if not self.sec_user_agent:
+            raise RuntimeError("SEC user agent is required for live EDGAR calls.")
         return self._fetch_live_html(ticker)
 
     def _fetch_live_html(self, ticker: str) -> Dict[str, str]:
@@ -36,38 +41,147 @@ class EdgarTool(BaseTool):
         if httpx is None:
             raise RuntimeError("httpx is required for live EDGAR calls but is not installed.")
         headers = {"User-Agent": self.sec_user_agent}
-        params = {"ticker": ticker, "type": "10-K", "count": 1}
-        with httpx.Client(timeout=10, headers=headers) as client:
-            response = client.get("https://data.sec.gov/submissions/CIK0001321655.json", params=params)
-            response.raise_for_status()
-        # Placeholder: in real implementation parse JSON to locate filing URL.
-        return {"ticker": ticker, "section": "Live EDGAR fetching not implemented in this offline build."}
+        params = {
+            "action": "getcompany",
+            "CIK": ticker,
+            "type": "10-K",
+            "count": 1,
+            "owner": "exclude",
+            "output": "atom",
+        }
+
+        with httpx.Client(timeout=15, headers=headers) as client:
+            feed_response = client.get("https://www.sec.gov/cgi-bin/browse-edgar", params=params)
+            feed_response.raise_for_status()
+
+            index_url, filed_on = self._parse_feed(feed_response.text)
+            document_url = self._locate_primary_document(client, index_url)
+            document_response = client.get(document_url)
+            document_response.raise_for_status()
+
+        section_text = self._extract_item7_section(document_response.text)
+        return {
+            "ticker": ticker,
+            "section": section_text,
+            "source_url": document_url,
+            "filed_on": filed_on,
+            "filing_type": "10-K",
+        }
+
+    def _parse_feed(self, feed_xml: str) -> tuple[str, Optional[str]]:
+        """Return the filing index URL and filing date from an Atom feed."""
+
+        namespace = {"atom": "http://www.w3.org/2005/Atom"}
+        root = ElementTree.fromstring(feed_xml)
+        entry = root.find("atom:entry", namespace)
+        if entry is None:
+            raise ValueError("No 10-K filings found in SEC feed.")
+
+        link_element = entry.find("atom:link", namespace)
+        if link_element is None or "href" not in link_element.attrib:
+            raise ValueError("SEC feed entry did not include a filing index link.")
+
+        summary = entry.findtext("atom:summary", default="", namespaces=namespace)
+        filed_on = self._extract_filed_date(summary)
+        if filed_on is None:
+            updated = entry.findtext("atom:updated", default="", namespaces=namespace)
+            filed_on = self._extract_updated_date(updated)
+
+        return link_element.attrib["href"], filed_on
 
     @staticmethod
-    def _extract_text(html: str) -> str:
-        class ParagraphCollector(HTMLParser):
-            def __init__(self) -> None:
-                super().__init__()
-                self.in_paragraph = False
-                self.chunks: list[str] = []
+    def _extract_filed_date(summary_html: str) -> Optional[str]:
+        """Extract the filed-on date from the summary block, if present."""
 
-            def handle_starttag(self, tag, attrs):  # type: ignore[override]
-                if tag.lower() == "p":
-                    self.in_paragraph = True
+        if not summary_html:
+            return None
+        match = re.search(r"Filed:\s*(\d{4}-\d{2}-\d{2})", summary_html)
+        if match:
+            return match.group(1)
+        return None
 
-            def handle_endtag(self, tag):  # type: ignore[override]
-                if tag.lower() == "p":
-                    self.in_paragraph = False
+    @staticmethod
+    def _extract_updated_date(value: str) -> Optional[str]:
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).date().isoformat()
+        except ValueError:
+            return None
 
-            def handle_data(self, data):  # type: ignore[override]
-                if self.in_paragraph:
-                    text = data.strip()
-                    if text:
-                        self.chunks.append(text)
+    def _locate_primary_document(self, client: httpx.Client, index_url: str) -> str:
+        """Find the primary 10-K document URL from the filing index page."""
 
-        parser = ParagraphCollector()
-        parser.feed(html)
-        return " ".join(parser.chunks)
+        response = client.get(index_url)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+        table = soup.find("table", class_="tableFile", summary="Document Format Files")
+        if table is None:
+            raise ValueError("Could not locate document table on the filing index page.")
+
+        for row in table.find_all("tr"):
+            cells = row.find_all("td")
+            if not cells or len(cells) < 2:
+                continue
+            form_type = cells[1].get_text(strip=True).upper()
+            if form_type != "10-K":
+                continue
+            link = row.find("a")
+            if link and link.get("href"):
+                href = link["href"]
+                if href.startswith("/ix?doc="):
+                    href = href.split("=", 1)[1]
+                return urljoin(index_url, href)
+
+        first_link = table.find("a")
+        if first_link and first_link.get("href"):
+            href = first_link["href"]
+            if href.startswith("/ix?doc="):
+                href = href.split("=", 1)[1]
+            return urljoin(index_url, href)
+        raise ValueError("Unable to resolve primary 10-K document link.")
+
+    @staticmethod
+    def _extract_item7_section(document_html: str) -> str:
+        """Extract Item 7 text from a 10-K HTML document."""
+
+        soup = BeautifulSoup(document_html, "html.parser")
+        heading = None
+        for candidate in soup.find_all(string=re.compile(r"Item\s+7\.", re.IGNORECASE)):
+            candidate_text = candidate.strip()
+            if not candidate_text:
+                continue
+            style = (candidate.parent.get("style") or "").lower() if candidate.parent else ""
+            if "font-weight:700" in style or candidate_text.isupper():
+                heading = candidate.parent
+                break
+        if heading is None:
+            matches = soup.find_all(string=re.compile(r"Item\s+7\.", re.IGNORECASE))
+            if matches:
+                heading = matches[-1].parent
+        if heading is None:
+            return "Unable to extract Item 7 management discussion from the filing."
+
+        container = heading.find_parent(["div", "p", "section", "article", "body"]) or heading
+        chunks: list[str] = []
+        for sibling in container.next_siblings:
+            if isinstance(sibling, NavigableString):
+                text_block = str(sibling).strip()
+            else:
+                text_block = sibling.get_text(" ", strip=True)
+            if not text_block:
+                continue
+            if re.search(r"Item\s+7A\.|Item\s+8\.", text_block, re.IGNORECASE):
+                break
+            chunks.append(text_block)
+            if len(" ".join(chunks)) >= 4000:
+                break
+
+        if not chunks:
+            return "Unable to extract Item 7 management discussion from the filing."
+
+        normalized = re.sub(r"\s+", " ", " ".join(chunks))
+        return normalized[:4000].strip()
 
 
 def build_edgar_tool(

--- a/tools/edgar.py
+++ b/tools/edgar.py
@@ -1,195 +1,197 @@
 """SEC EDGAR helper to retrieve filing excerpts."""
 from __future__ import annotations
 
+import json
 import re
-from datetime import datetime
+import time
 from pathlib import Path
-from typing import Dict, Optional
-from urllib.parse import urljoin
-from xml.etree import ElementTree
+from typing import Dict, Iterable, List, Optional
 
 try:  # pragma: no cover - optional dependency for live mode
     import httpx
 except Exception:  # pragma: no cover - offline fallback
     httpx = None
 
-from bs4 import BeautifulSoup, NavigableString
+from bs4 import BeautifulSoup
 from strands.tools import tool
 from strands.tools.decorator import DecoratedFunctionTool
 
-from .base import BaseTool, json_tool_response
+from .base import json_tool_response
 
 
-class EdgarTool(BaseTool):
-    """Fetch Item 7 style MD&A snippets for a ticker."""
+SEC_TICKER_URL = "https://www.sec.gov/files/company_tickers.json"
+SEC_SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
+SEC_ARCHIVES_URL = "https://www.sec.gov/Archives/edgar/data/{cik_no_zeros}/{accession_no_dashes}/{doc}"
 
-    def __init__(self, *, use_fixtures: bool, fixtures_path: Path, sec_user_agent: str | None) -> None:
-        super().__init__(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+DEFAULT_FORMS: tuple[str, ...] = ("10-K", "10-Q", "20-F", "40-F", "F-10", "6-K")
+DEFAULT_SECTION_PATTERNS: tuple[str, ...] = (
+    r"Item\s+7\.",
+    r"Item\s+5\.\s+Management's Discussion and Analysis",
+    r"MANAGEMENT['\"]?S\s+DISCUSSION\s+AND\s+ANALYSIS",
+    r"Management.?s\s+Discussion\s+and\s+Analysis",
+)
+
+
+def _ensure_http_client() -> None:
+    if httpx is None:  # pragma: no cover - dependency enforcement
+        raise RuntimeError("httpx is required for live EDGAR calls but is not installed.")
+
+
+def _headers(sec_user_agent: str) -> Dict[str, str]:
+    return {"User-Agent": sec_user_agent, "Accept-Encoding": "gzip, deflate"}
+
+
+def _throttled_get(url: str, *, headers: Dict[str, str], params: Optional[Dict[str, str]] = None, retries: int = 3) -> httpx.Response:
+    last_exc: Optional[Exception] = None
+    for attempt in range(retries):
+        try:
+            response = httpx.get(url, params=params, headers=headers, timeout=30)
+            if response.status_code in {429, 500, 502, 503, 504}:
+                time.sleep(0.5 * (2 ** attempt))
+                continue
+            response.raise_for_status()
+            time.sleep(0.25)
+            return response
+        except Exception as exc:  # pragma: no cover - network specific
+            last_exc = exc
+            time.sleep(0.5 * (2 ** attempt))
+    if last_exc:
+        raise last_exc
+    raise RuntimeError(f"Request to {url} failed without exception detail")
+
+
+def _load_ticker_map(headers: Dict[str, str], cache_path: Path) -> Dict[str, str]:
+    if cache_path.exists() and time.time() - cache_path.stat().st_mtime < 7 * 24 * 3600:
+        data = json.loads(cache_path.read_text())
+    else:
+        response = _throttled_get(SEC_TICKER_URL, headers=headers)
+        data = response.json()
+        cache_path.write_text(json.dumps(data))
+
+    mapping: Dict[str, str] = {}
+    for payload in data.values():
+        cik = str(payload["cik_str"]).zfill(10)
+        mapping[payload["ticker"].upper()] = cik
+    return mapping
+
+
+def _recent_filing_metadata(
+    cik: str,
+    *,
+    forms: Iterable[str],
+    headers: Dict[str, str],
+    limit: int = 5,
+) -> List[Dict[str, str]]:
+    response = _throttled_get(SEC_SUBMISSIONS_URL.format(cik=cik), headers=headers)
+    data = response.json()
+
+    filings = data.get("filings", {}).get("recent", {})
+    form_list = filings.get("form", [])
+    accession_numbers = filings.get("accessionNumber", [])
+    primary_documents = filings.get("primaryDocument", [])
+    filed_dates = filings.get("filingDate", [])
+
+    target_forms = {form.upper() for form in forms}
+    results: List[Dict[str, str]] = []
+    for form, accession, primary_doc, filed_on in zip(form_list, accession_numbers, primary_documents, filed_dates):
+        if form.upper() not in target_forms:
+            continue
+        if not primary_doc.lower().endswith((".htm", ".html")):
+            continue
+        accession_no_dashes = accession.replace("-", "")
+        cik_no_zeros = cik.lstrip("0") or "0"
+        url = SEC_ARCHIVES_URL.format(
+            cik_no_zeros=cik_no_zeros,
+            accession_no_dashes=accession_no_dashes,
+            doc=primary_doc,
+        )
+        results.append(
+            {
+                "form": form,
+                "accession": accession,
+                "filing_date": filed_on,
+                "primary_document": primary_doc,
+                "url": url,
+            }
+        )
+        if len(results) >= limit:
+            break
+    return results
+
+
+def _extract_section(html: str, patterns: Iterable[str], *, max_chars: int = 20000) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text("\n")
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if not match:
+            continue
+        start = match.start()
+        end = min(len(text), start + max_chars)
+        snippet = text[start:end]
+        snippet = re.sub(r"\s+", " ", snippet)
+        return snippet.strip()
+    raise ValueError("Requested filing section not found in document.")
+
+
+class EdgarTool:
+    """Fetch filing sections from live SEC data using the submissions API."""
+
+    def __init__(self, *, sec_user_agent: str | None) -> None:
         self.sec_user_agent = sec_user_agent
+        self.cache_dir = Path(".sec_cache")
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def fetch(self, ticker: str) -> Dict[str, str]:
         ticker = ticker.upper()
-        if self.use_fixtures:
-            raise RuntimeError("Fixture mode is disabled; live SEC data is required.")
-        if not self.sec_user_agent:
-            raise RuntimeError("SEC user agent is required for live EDGAR calls.")
-        return self._fetch_live_html(ticker)
+        if not self.sec_user_agent or "@" not in self.sec_user_agent:
+            raise RuntimeError("SEC_UA must be set with a valid contact email for EDGAR access.")
 
-    def _fetch_live_html(self, ticker: str) -> Dict[str, str]:
-        if not self.sec_user_agent:
-            raise RuntimeError("SEC user agent is required for live EDGAR calls.")
-        if httpx is None:
-            raise RuntimeError("httpx is required for live EDGAR calls but is not installed.")
-        headers = {"User-Agent": self.sec_user_agent}
-        params = {
-            "action": "getcompany",
-            "CIK": ticker,
-            "type": "10-K",
-            "count": 1,
-            "owner": "exclude",
-            "output": "atom",
-        }
+        _ensure_http_client()
+        headers = _headers(self.sec_user_agent)
+        ticker_map = _load_ticker_map(headers, self.cache_dir / "company_tickers.json")
+        cik = ticker_map.get(ticker)
+        if not cik:
+            raise ValueError(f"Ticker '{ticker}' not found in SEC company list.")
 
-        with httpx.Client(timeout=15, headers=headers) as client:
-            feed_response = client.get("https://www.sec.gov/cgi-bin/browse-edgar", params=params)
-            feed_response.raise_for_status()
+        metadata_candidates = _recent_filing_metadata(cik, forms=DEFAULT_FORMS, headers=headers)
+        if not metadata_candidates:
+            raise RuntimeError("Unable to locate a recent filing with an HTML primary document for this ticker.")
 
-            index_url, filed_on = self._parse_feed(feed_response.text)
-            document_url = self._locate_primary_document(client, index_url)
-            document_response = client.get(document_url)
-            document_response.raise_for_status()
+        extraction_errors: List[str] = []
+        for metadata in metadata_candidates:
+            filing_response = _throttled_get(metadata["url"], headers=headers)
+            try:
+                section_text = _extract_section(filing_response.text, DEFAULT_SECTION_PATTERNS)
+            except ValueError as exc:
+                extraction_errors.append(f"{metadata['form']} {metadata['accession']}: {exc}")
+                continue
 
-        section_text = self._extract_item7_section(document_response.text)
+            return {
+                "ticker": ticker,
+                "section": section_text,
+                "source_url": metadata["url"],
+                "filed_on": metadata["filing_date"],
+                "filing_type": metadata["form"],
+                "accession": metadata["accession"],
+            }
+
+        fallback = metadata_candidates[0]
         return {
             "ticker": ticker,
-            "section": section_text,
-            "source_url": document_url,
-            "filed_on": filed_on,
-            "filing_type": "10-K",
+            "section": "",
+            "source_url": fallback["url"],
+            "filed_on": fallback["filing_date"],
+            "filing_type": fallback["form"],
+            "accession": fallback["accession"],
+            "error": "; ".join(extraction_errors) or "Requested filing section not found",
         }
 
-    def _parse_feed(self, feed_xml: str) -> tuple[str, Optional[str]]:
-        """Return the filing index URL and filing date from an Atom feed."""
 
-        namespace = {"atom": "http://www.w3.org/2005/Atom"}
-        root = ElementTree.fromstring(feed_xml)
-        entry = root.find("atom:entry", namespace)
-        if entry is None:
-            raise ValueError("No 10-K filings found in SEC feed.")
-
-        link_element = entry.find("atom:link", namespace)
-        if link_element is None or "href" not in link_element.attrib:
-            raise ValueError("SEC feed entry did not include a filing index link.")
-
-        summary = entry.findtext("atom:summary", default="", namespaces=namespace)
-        filed_on = self._extract_filed_date(summary)
-        if filed_on is None:
-            updated = entry.findtext("atom:updated", default="", namespaces=namespace)
-            filed_on = self._extract_updated_date(updated)
-
-        return link_element.attrib["href"], filed_on
-
-    @staticmethod
-    def _extract_filed_date(summary_html: str) -> Optional[str]:
-        """Extract the filed-on date from the summary block, if present."""
-
-        if not summary_html:
-            return None
-        match = re.search(r"Filed:\s*(\d{4}-\d{2}-\d{2})", summary_html)
-        if match:
-            return match.group(1)
-        return None
-
-    @staticmethod
-    def _extract_updated_date(value: str) -> Optional[str]:
-        if not value:
-            return None
-        try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00")).date().isoformat()
-        except ValueError:
-            return None
-
-    def _locate_primary_document(self, client: httpx.Client, index_url: str) -> str:
-        """Find the primary 10-K document URL from the filing index page."""
-
-        response = client.get(index_url)
-        response.raise_for_status()
-        soup = BeautifulSoup(response.text, "html.parser")
-        table = soup.find("table", class_="tableFile", summary="Document Format Files")
-        if table is None:
-            raise ValueError("Could not locate document table on the filing index page.")
-
-        for row in table.find_all("tr"):
-            cells = row.find_all("td")
-            if not cells or len(cells) < 2:
-                continue
-            form_type = cells[1].get_text(strip=True).upper()
-            if form_type != "10-K":
-                continue
-            link = row.find("a")
-            if link and link.get("href"):
-                href = link["href"]
-                if href.startswith("/ix?doc="):
-                    href = href.split("=", 1)[1]
-                return urljoin(index_url, href)
-
-        first_link = table.find("a")
-        if first_link and first_link.get("href"):
-            href = first_link["href"]
-            if href.startswith("/ix?doc="):
-                href = href.split("=", 1)[1]
-            return urljoin(index_url, href)
-        raise ValueError("Unable to resolve primary 10-K document link.")
-
-    @staticmethod
-    def _extract_item7_section(document_html: str) -> str:
-        """Extract Item 7 text from a 10-K HTML document."""
-
-        soup = BeautifulSoup(document_html, "html.parser")
-        heading = None
-        for candidate in soup.find_all(string=re.compile(r"Item\s+7\.", re.IGNORECASE)):
-            candidate_text = candidate.strip()
-            if not candidate_text:
-                continue
-            style = (candidate.parent.get("style") or "").lower() if candidate.parent else ""
-            if "font-weight:700" in style or candidate_text.isupper():
-                heading = candidate.parent
-                break
-        if heading is None:
-            matches = soup.find_all(string=re.compile(r"Item\s+7\.", re.IGNORECASE))
-            if matches:
-                heading = matches[-1].parent
-        if heading is None:
-            return "Unable to extract Item 7 management discussion from the filing."
-
-        container = heading.find_parent(["div", "p", "section", "article", "body"]) or heading
-        chunks: list[str] = []
-        for sibling in container.next_siblings:
-            if isinstance(sibling, NavigableString):
-                text_block = str(sibling).strip()
-            else:
-                text_block = sibling.get_text(" ", strip=True)
-            if not text_block:
-                continue
-            if re.search(r"Item\s+7A\.|Item\s+8\.", text_block, re.IGNORECASE):
-                break
-            chunks.append(text_block)
-            if len(" ".join(chunks)) >= 4000:
-                break
-
-        if not chunks:
-            return "Unable to extract Item 7 management discussion from the filing."
-
-        normalized = re.sub(r"\s+", " ", " ".join(chunks))
-        return normalized[:4000].strip()
-
-
-def build_edgar_tool(
-    *, use_fixtures: bool, fixtures_path: Path, sec_user_agent: str | None
-) -> DecoratedFunctionTool:
+def build_edgar_tool(*, sec_user_agent: str | None) -> DecoratedFunctionTool:
     """Create a Strands tool for fetching SEC MD&A excerpts."""
 
-    backend = EdgarTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path, sec_user_agent=sec_user_agent)
+    backend = EdgarTool(sec_user_agent=sec_user_agent)
 
     @tool(name="edgar", description="Fetch Item 7 management commentary for a ticker.")
     def edgar_tool(ticker: str) -> Dict[str, str]:

--- a/tools/news.py
+++ b/tools/news.py
@@ -25,11 +25,13 @@ class NewsTool(BaseTool):
 
     def fetch(self, ticker: str) -> Dict[str, Any]:
         ticker = ticker.upper()
-        if self.use_fixtures or not self.news_token:
-            return self.load_fixture_json(f"news_{ticker}.json")
-        return self._fetch_live_news(ticker)
+        if self.use_fixtures:
+            raise RuntimeError("Fixture mode is disabled; live news data is required.")
+        if self.news_token:
+            return self._fetch_newsapi_headlines(ticker)
+        return self._fetch_gdelt_headlines(ticker)
 
-    def _fetch_live_news(self, ticker: str) -> Dict[str, Any]:
+    def _fetch_newsapi_headlines(self, ticker: str) -> Dict[str, Any]:
         if httpx is None:
             raise RuntimeError("httpx is required for live news fetching but is not installed.")
         end = datetime.utcnow()
@@ -47,16 +49,51 @@ class NewsTool(BaseTool):
             response = client.get("https://newsapi.org/v2/everything", params=params)
             response.raise_for_status()
         payload = response.json()
-        articles = []
-        for article in payload.get("articles", []):
-            articles.append(
+        return {
+            "ticker": ticker,
+            "articles": [
                 {
                     "title": article.get("title"),
                     "summary": article.get("description"),
                     "url": article.get("url"),
-                    "published_at": article.get("publishedAt", "")[:10],
+                    "published_at": (article.get("publishedAt") or "")[:10],
                     "sentiment": self._naive_sentiment(article.get("description", "")),
                     "source": article.get("source", {}).get("name"),
+                }
+                for article in payload.get("articles", [])
+            ],
+        }
+
+    def _fetch_gdelt_headlines(self, ticker: str) -> Dict[str, Any]:
+        if httpx is None:
+            raise RuntimeError("httpx is required for live news fetching but is not installed.")
+
+        params = {
+            "query": ticker,
+            "mode": "ArtList",
+            "format": "json",
+            "maxrecords": 10,
+        }
+        with httpx.Client(timeout=10) as client:
+            response = client.get("https://api.gdeltproject.org/api/v2/doc/doc", params=params)
+            response.raise_for_status()
+        payload = response.json()
+        articles: List[Dict[str, Any]] = []
+        for article in payload.get("articles", []):
+            summary = article.get("seendescription") or article.get("themes") or ""
+            raw_date = article.get("seendate", "") or ""
+            if len(raw_date) == 8 and raw_date.isdigit():
+                published_at = f"{raw_date[:4]}-{raw_date[4:6]}-{raw_date[6:8]}"
+            else:
+                published_at = raw_date
+            articles.append(
+                {
+                    "title": article.get("title") or article.get("sourcecommonname"),
+                    "summary": summary,
+                    "url": article.get("url"),
+                    "published_at": published_at,
+                    "sentiment": self._naive_sentiment(summary),
+                    "source": article.get("sourcecommonname"),
                 }
             )
         return {"ticker": ticker, "articles": articles}

--- a/tools/news.py
+++ b/tools/news.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Any, Dict, List
 
 try:  # pragma: no cover - optional dependency for live mode
@@ -13,20 +12,17 @@ except Exception:  # pragma: no cover - offline fallback
 from strands.tools import tool
 from strands.tools.decorator import DecoratedFunctionTool
 
-from .base import BaseTool, json_tool_response
+from .base import json_tool_response
 
 
-class NewsTool(BaseTool):
-    """Fetch recent headlines for a ticker using NewsAPI or fixtures."""
+class NewsTool:
+    """Fetch recent headlines for a ticker using live news providers."""
 
-    def __init__(self, *, use_fixtures: bool, fixtures_path: Path, news_token: str | None) -> None:
-        super().__init__(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+    def __init__(self, *, news_token: str | None) -> None:
         self.news_token = news_token
 
     def fetch(self, ticker: str) -> Dict[str, Any]:
         ticker = ticker.upper()
-        if self.use_fixtures:
-            raise RuntimeError("Fixture mode is disabled; live news data is required.")
         if self.news_token:
             return self._fetch_newsapi_headlines(ticker)
         return self._fetch_gdelt_headlines(ticker)
@@ -111,12 +107,10 @@ class NewsTool(BaseTool):
         return round((positive - negative) / total, 2)
 
 
-def build_news_tool(
-    *, use_fixtures: bool, fixtures_path: Path, news_token: str | None
-) -> DecoratedFunctionTool:
+def build_news_tool(*, news_token: str | None) -> DecoratedFunctionTool:
     """Create a Strands tool that fetches recent news articles."""
 
-    backend = NewsTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path, news_token=news_token)
+    backend = NewsTool(news_token=news_token)
 
     @tool(name="news", description="Fetch NewsAPI headlines and naive sentiment for a ticker symbol.")
     def news_tool(ticker: str) -> Dict[str, Any]:

--- a/tools/peers.py
+++ b/tools/peers.py
@@ -1,13 +1,12 @@
 """Hard-coded peer groups for key tickers."""
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Dict, List
 
 from strands.tools import tool
 from strands.tools.decorator import DecoratedFunctionTool
 
-from .base import BaseTool, json_tool_response
+from .base import json_tool_response
 
 
 _PEER_MAP: Dict[str, List[str]] = {
@@ -17,11 +16,8 @@ _PEER_MAP: Dict[str, List[str]] = {
 }
 
 
-class PeersTool(BaseTool):
+class PeersTool:
     """Return a static peer group for a ticker."""
-
-    def __init__(self, *, use_fixtures: bool, fixtures_path: Path) -> None:
-        super().__init__(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
 
     def fetch(self, ticker: str) -> Dict[str, List[str]]:
         ticker = ticker.upper()
@@ -29,10 +25,10 @@ class PeersTool(BaseTool):
         return {"ticker": ticker, "peers": peers}
 
 
-def build_peers_tool(*, use_fixtures: bool, fixtures_path: Path) -> DecoratedFunctionTool:
+def build_peers_tool() -> DecoratedFunctionTool:
     """Create a Strands tool that returns static peer groups."""
 
-    backend = PeersTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+    backend = PeersTool()
 
     @tool(name="peers", description="Return a static list of comparable tickers for the target company.")
     def peers_tool(ticker: str) -> Dict[str, List[str]]:

--- a/tools/prices.py
+++ b/tools/prices.py
@@ -24,7 +24,7 @@ class PricesTool(BaseTool):
     def fetch(self, ticker: str) -> Dict[str, Any]:
         ticker = ticker.upper()
         if self.use_fixtures:
-            return self.load_fixture_json(f"prices_{ticker}.json")
+            raise RuntimeError("Fixture mode is disabled; live market data is required.")
         if yf is None:
             raise RuntimeError("yfinance is required for live price fetching but is not installed.")
 

--- a/tools/ratios.py
+++ b/tools/ratios.py
@@ -1,13 +1,12 @@
 """Technical ratio helpers derived from price history."""
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
 from strands.tools import tool
 from strands.tools.decorator import DecoratedFunctionTool
 
-from .base import BaseTool, json_tool_response
+from .base import json_tool_response
 
 
 def _sma(values: Iterable[float]) -> float:
@@ -36,11 +35,8 @@ def _rsi(prices: List[float], period: int = 14) -> float:
     return round(100 - (100 / (1 + rs)), 2)
 
 
-class RatiosTool(BaseTool):
+class RatiosTool:
     """Compute SMA20, SMA50, and RSI14 from price history."""
-
-    def __init__(self, *, use_fixtures: bool, fixtures_path: Path) -> None:
-        super().__init__(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
 
     def compute(self, price_payload: Dict[str, Any]) -> Dict[str, float]:
         history = price_payload.get("history", [])
@@ -53,10 +49,10 @@ class RatiosTool(BaseTool):
         }
 
 
-def build_ratios_tool(*, use_fixtures: bool, fixtures_path: Path) -> DecoratedFunctionTool:
+def build_ratios_tool() -> DecoratedFunctionTool:
     """Create a Strands tool to compute technical ratios from price payloads."""
 
-    backend = RatiosTool(use_fixtures=use_fixtures, fixtures_path=fixtures_path)
+    backend = RatiosTool()
 
     @tool(name="ratios", description="Compute SMA and RSI metrics from price history data.")
     def ratios_tool(price_payload: Dict[str, Any]) -> Dict[str, float]:


### PR DESCRIPTION
## Summary
- wire the local runner into the Strands agent runtime with live-only tools (Yahoo Finance prices/ratios, NewsAPI→GDELT news, SEC submissions scraper, static peers)
- make OpenAI the default model provider with AWS Bedrock as a fallback, sharing the same agent plumbing and env-var driven configuration
- harden the agent/runtime: structured output required, tool failures collected via , and SEC parsing resilient when MD&A text is missing
- document the live flow in the README (including a sample AMZN run) and clean settings/tests for the online-only mode